### PR TITLE
Fix random WebSocket disconnects.

### DIFF
--- a/fortnitepy/store.py
+++ b/fortnitepy/store.py
@@ -215,6 +215,34 @@ class DailyStoreItem(StoreItemBase):
                 'price={0.price!r}>'.format(self))
 
 
+class SpecialFeaturedStoreItem(StoreItemBase):
+    """Special featured store item."""
+    def __init__(self, data: dict) -> None:
+        super().__init__(data)
+        self._panel = int((data['categories'][0].split(' '))[1])
+
+    def __repr__(self) -> str:
+        return ('<SpecialFeaturedStoreItem dev_name={0.dev_name!r} '
+                'asset={0.asset!r} price={0.price!r}>'.format(self))
+
+    @property
+    def panel(self) -> int:
+        """:class:`int`: The panel the item is listed in from left
+        to right.
+        """
+        return self._panel
+
+
+class SpecialDailyStoreItem(StoreItemBase):
+    """Special daily store item."""
+    def __init__(self, data: dict) -> None:
+        super().__init__(data)
+
+    def __repr__(self) -> str:
+        return ('<SpecialDailyStoreItem dev_name={0.dev_name!r} '
+                'asset={0.asset!r} price={0.price!r}>'.format(self))
+
+
 class Store:
     """Object representing store data from Fortnite Battle Royale.
 
@@ -231,6 +259,9 @@ class Store:
 
         self._featured_items = self._create_featured_items(data)
         self._daily_items = self._create_daily_items(data)
+        self._special_featured_items = \
+            self._create_special_featured_items(data)
+        self._special_daily_items = self._create_special_daily_items(data)
 
     def __repr__(self) -> str:
         return ('<Store created_at={0.created_at!r} '
@@ -249,6 +280,20 @@ class Store:
         daily items in the item shop.
         """
         return self._daily_items
+
+    @property
+    def special_featured_items(self) -> List[SpecialFeaturedStoreItem]:
+        """List[:class:`SpecialFeaturedStoreItem`]: A list containing data about
+        special featured items in the item shop.
+        """
+        return self._special_featured_items
+
+    @property
+    def special_daily_items(self) -> List[SpecialDailyStoreItem]:
+        """List[:class:`SpecialDailyStoreItem`]: A list containing data about
+        special daily items in the item shop.
+        """
+        return self._special_daily_items
 
     @property
     def daily_purchase_hours(self) -> int:
@@ -295,4 +340,24 @@ class Store:
         res = []
         for item in storefront['catalogEntries']:
             res.append(DailyStoreItem(item))
+        return res
+
+    def _create_special_featured_items(self,
+                                       data: dict
+                                       ) -> List[SpecialFeaturedStoreItem]:
+        storefront = self._find_storefront(data, 'BRSpecialFeatured')
+
+        res = []
+        for item in storefront['catalogEntries']:
+            res.append(SpecialFeaturedStoreItem(item))
+        return res
+
+    def _create_special_daily_items(self,
+                                    data: dict
+                                    ) -> List[SpecialDailyStoreItem]:
+        storefront = self._find_storefront(data, 'BRSpecialDaily')
+
+        res = []
+        for item in storefront['catalogEntries']:
+            res.append(SpecialDailyStoreItem(item))
         return res

--- a/fortnitepy/xmpp.py
+++ b/fortnitepy/xmpp.py
@@ -32,7 +32,7 @@ import datetime
 import uuid
 import itertools
 import unicodedata
-import websockets
+import aiohttp
 
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, Union, Awaitable, Any
@@ -123,7 +123,8 @@ class WebsocketTransport:
         self._close_event = asyncio.Event()
 
     async def create_connection(self, *args, **kwargs):
-        self.connection = con = await websockets.connect(
+        self.session = aiohttp.ClientSession()
+        self.connection = con = await self.session.ws_connect(
             *args, **kwargs
         )
         self.loop.create_task(self.reader())
@@ -131,14 +132,19 @@ class WebsocketTransport:
         return con
 
     async def reader(self):
-        try:
-            async for data in self.connection:
-                self.stream.data_received(data)
-        except websockets.ConnectionClosedError:
-            pass
+        while True:
+            msg = await self.connection.receive()
+
+            if msg.type == aiohttp.WSMsgType.text:
+                self.stream.data_received(msg.data)
+            if msg.type == aiohttp.WSMsgType.closed:
+                break
+            if msg.type == aiohttp.WSMsgType.error:
+                print('Error')
+                break
 
     async def send(self, data):
-        await self.connection.send(data)
+        await self.connection.send_bytes(data)
 
     def write(self, data):
         self._buffer += data
@@ -169,14 +175,14 @@ class WebsocketTransport:
         self._stop_reader()
 
     def abort(self):
-        self.connection.transport.abort()
+        self.connection._response.connection.transport.abort()
         self._stop_reader()
 
     async def wait_closed(self):
         await self._close_event
 
     def get_extra_info(self, *args, **kwargs):
-        return self.connection.transport.get_extra_info(*args, **kwargs)
+        return self.connection.get_extra_info(*args, **kwargs)
 
 
 class WebsocketXMLStreamWriter(aioxmpp.xml.XMLStreamWriter):
@@ -243,8 +249,7 @@ class XMPPOverWebsocketConnector(aioxmpp.connector.BaseConnector):
         transport = WebsocketTransport(stream)
         await transport.create_connection(
             'wss://{0}'.format(host),
-            subprotocols=('xmpp',),
-            ping_interval=None
+            protocols=('xmpp',),
         )
 
         return transport, stream, await features_future

--- a/fortnitepy/xmpp.py
+++ b/fortnitepy/xmpp.py
@@ -244,6 +244,7 @@ class XMPPOverWebsocketConnector(aioxmpp.connector.BaseConnector):
         await transport.create_connection(
             'wss://{0}'.format(host),
             subprotocols=('xmpp',),
+            ping_interval=None
         )
 
         return transport, stream, await features_future


### PR DESCRIPTION
Removing the ping interval seems to stop the random WebSocket disconnects you would get like the error below:
```python
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.7/site-packages/fortnitepy/xmpp.py", line 141, in send
    await self.connection.send(data)
  File "/home/ubuntu/.local/lib/python3.7/site-packages/websockets/protocol.py", line 555, in send
    await self.ensure_open()
  File "/home/ubuntu/.local/lib/python3.7/site-packages/websockets/protocol.py", line 803, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: code = 1006 (connection closed abnormally [internal]), no reason
```
(For proof, ran 17 bots and I haven't had a disconnect in ~9 hours compared to the disconnects I'd get prior which were instant).