### PR TITLE
Updated authentication in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -110,8 +110,7 @@ client.
 .. code-block:: python3
 
     client = fortnitepy.Client(
-        email="email@email.com,
-        password="password1",
+        auth=fortnitepy.Auth, // Here goes an authentication method like fortnitepy.AdvancedAuth or fortnitepy.EmailAndPasswordAuth
         status="This is my status"
     )
 
@@ -181,8 +180,7 @@ with the correct one yourself.
 
     # pass the netcl to with the net_cl keyword when initializing the client.
     client = fortnitepy.Client(
-        email='email',
-        password='password',
+        auth=fortnitepy.Auth, // Here goes an authentication method like fortnitepy.AdvancedAuth or fortnitepy.EmailAndPasswordAuth
         net_cl='7605985'
     )
 


### PR DESCRIPTION
Well, the FAQ still used the old authentication method with the `email` and `password` kwargs which could mislead someone reading the FAQ these days. I replaced these references with the base class of `fortnitepy.Auth` and a little comment telling them that they should use any type of authentication there. I think this could also be updated to not include the code snippet and instead refer to the `status` and `netcl` kwarg without the code