### PR TITLE
Fixed XMPP message "vulnerability"

### DIFF
--- a/fortnitepy/xmpp.py
+++ b/fortnitepy/xmpp.py
@@ -177,6 +177,10 @@ class XMLProcessor:
     def _process_message(self, raw: str) -> Optional[Union[tuple, bool]]:
         tree = ElementTree.fromstring(raw)
 
+        # Only intercept messages sent by epic
+        if tree.get('from', '') != 'xmpp-admin@prod.ol.epicgames.com':
+            return False
+
         type_ = tree.get('type')
 
         # Only intercept messages with either no type attribute


### PR DESCRIPTION
Fortnitepy doesn't check if an XMPP message was actually sent by epic.

That way you can send the bot a MEMBER_KICKED xmpp message and make it think that it got kicked from its party which makes it leave its party. So basically, you can kick the bot from its own party. [Example](https://cdn.discordapp.com/attachments/700328884129759248/871385981360701440/e5bz7P8eMM.mp4)

But there's also much more you can do such as messing up the bot's friend cache by sending FRIENDSHIP_REMOVE, Friend, etc XMPP messages, spamming fortnitepy errors, messing up the bots party, and probably many other things.

Oh and btw, this does not break friend messages or presences.