### PR TITLE
added timeout in accept_friend

### DIFF
--- a/fortnitepy/client.py
+++ b/fortnitepy/client.py
@@ -2122,7 +2122,8 @@ class Client:
         """
         await self.add_friend(user_id)
         friend = await self.wait_for('friend_add',
-                                     check=lambda f: f.id == user_id)
+                                     check=lambda f: f.id == user_id,
+                                     timeout = 60)
         return friend
 
     async def remove_or_decline_friend(self, user_id: str) -> None:


### PR DESCRIPTION
The Client.accept_friend method calls the Client.wait_for method without any timeout parameter. As a result, when asyncio.wait_for is called in Client.wait_for, `timeout = None` is passed which causes a block until the future `check=lambda f: f.id == user_id` completes. This pull request just adds a 60 second timeout so that, in the event that the future never completes, accept_friend does not block.