### PR TITLE
Improve is_id & is_display_name functions and add new Season timestamps

### DIFF
--- a/fortnitepy/client.py
+++ b/fortnitepy/client.py
@@ -1977,7 +1977,8 @@ class Client:
         """
         await self.http.friends_unblock(user_id)
 
-    def is_id(self, value: str) -> bool:
+    @staticmethod
+    def is_id(value: str) -> bool:
         """Simple function that finds out if a :class:`str` is a valid id
 
         Parameters
@@ -1990,9 +1991,10 @@ class Client:
         :class:`bool`
             ``True`` if string is valid else ``False``
         """
-        return isinstance(value, str) and len(value) > 16
+        return isinstance(value, str) and len(value) > 16 and value.isalnum()
 
-    def is_display_name(self, val: str) -> bool:
+    @staticmethod
+    def is_display_name(value: str) -> bool:
         """Simple function that finds out if a :class:`str` is a valid displayname
 
         Parameters
@@ -2005,7 +2007,7 @@ class Client:
         :class:`bool`
             ``True`` if string is valid else ``False``
         """
-        return isinstance(val, str) and 3 <= len(val) <= 16
+        return isinstance(value, str) and 3 <= len(value) <= 16
 
     async def add_friend(self, user_id: str) -> None:
         """|coro|

--- a/fortnitepy/enums.py
+++ b/fortnitepy/enums.py
@@ -216,7 +216,8 @@ class SeasonStartTimestamp(Enum):
     SEASON_14 = 1598486401
     SEASON_15 = 1606867201
     SEASON_16 = 1615852801
-    SEASON_17 = 1623110401
+    SEASON_17 = 1623110400
+    SEASON_18 = 1631491200
 
 
 class SeasonEndTimestamp(Enum):
@@ -236,6 +237,7 @@ class SeasonEndTimestamp(Enum):
     SEASON_14 = 1606867200
     SEASON_15 = 1615852800
     SEASON_16 = 1623110400
+    Season_17 = 1631491200
 
 
 class BattlePassStat(Enum):
@@ -245,7 +247,8 @@ class BattlePassStat(Enum):
     SEASON_14 = ('s14_social_bp_level', SeasonEndTimestamp.SEASON_14.value)
     SEASON_15 = ('s15_social_bp_level', SeasonEndTimestamp.SEASON_15.value)
     SEASON_16 = ('s16_social_bp_level', SeasonEndTimestamp.SEASON_16.value)
-    SEASON_17 = ('s17_social_bp_level', None)
+    SEASON_17 = ('s17_social_bp_level', SeasonEndTimestamp.Season_17.value)
+    SEASON_18 = ('s18_social_bp_level', None)
 
 
 class KairosBackgroundColorPreset(Enum):


### PR DESCRIPTION
This pr adds the following improvements:
- `Client.is_id` and `Client.is_display_name` are now static
- `Client.is_id` has been improved by checking if the id is alphanumeric
- Season 17 start timestamp has been fixed when using it with the stats API
- Season 18 start timestamp has been added
- Season 17 end timestamp has been added
- Season 17 Battle pass stat has been completed & Season 18 Battle pass Stat has been added