### PR TITLE
Add `mnmonic` to `PlaylistData`

### DIFF
--- a/fortnitepy/party.py
+++ b/fortnitepy/party.py
@@ -5,7 +5,7 @@ MIT License
 
 Copyright (c) 2019-2021 Terbau
 
-Permission is hereby granted, free of charge, to any person obtaining a copyin
+Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell


### PR DESCRIPTION
The idea is that when this is set while other playlist data is modified with `set_playlist`, it can confuse the Fortnite client and set the playlist to `NoPlaylist`, resulting in the user actually queueing for the last gamemode they selected (rather than the one displayed).

This patch is currently untested.