### PR TITLE
add date of birth using the corrections endpoint if required

### DIFF
--- a/fortnitepy/http.py
+++ b/fortnitepy/http.py
@@ -1019,6 +1019,13 @@ class HTTPClient:
         r = AccountPublicService('/account/api/oauth/token')
         return await self.post(r, **kwargs)
 
+    async def account_put_date_of_birth_correction(self, continuation: str, date_of_birth: str, auth: str):
+        r = AccountPublicService(
+            '/account/api/public/corrections/dateOfBirth',
+        )
+
+        return await self.put(r, json={ 'continuation': continuation, 'dateOfBirth': date_of_birth }, auth=auth)
+
     async def account_generate_device_auth(self, client_id: str) -> dict:
         r = AccountPublicService(
             '/account/api/public/account/{client_id}/deviceAuth',


### PR DESCRIPTION
Epic requires all accounts to have a date of birth set and prevents logging in if you don't have it.
![grafik](https://user-images.githubusercontent.com/23171488/208257881-f71c337f-ac2c-474b-8647-b523a4e5f32c.png)

This PR handles this by setting the birthday to a random date between 1995 and 2003 if this is the case for an account.